### PR TITLE
coreclr: Using base class to share TraceListener between Debug and Trace

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -9,101 +9,139 @@ using System.Runtime.CompilerServices;
 
 namespace System.Diagnostics
 {
+    public abstract class TraceDebugBase
+    {
+        public abstract bool AutoFlush { get; set; }
+        public abstract void Assert(bool condition);
+        public abstract void Assert(bool condition, string message);
+        public abstract void Assert(bool condition, string message, string detailMessage);
+        public abstract void Close();
+        public abstract void Fail(string message);
+        public abstract void Fail(string message, string detailMessage);
+        public abstract void Flush();
+        public abstract int IndentLevel { get; set; }
+        public abstract int IndentSize { get; set; }
+        public abstract void Indent();
+        public abstract void Unindent();
+        public abstract void Write(object value);
+        public abstract void Write(object value, string category);
+        public abstract void Write(string message);
+        public abstract void Write(string message, string category);
+        public abstract void WriteLine(object value);
+        public abstract void WriteLine(object value, string category);
+        public abstract void WriteLine(string message);
+        public abstract void WriteLine(string message, string category);
+    }
+
     /// <summary>
     /// Provides a set of properties and methods for debugging code.
     /// </summary>
     public static partial class Debug
     {
-        private static readonly object s_lock = new object();
-
-        public static bool AutoFlush { get { return true; } set { } }
-
         [ThreadStatic]
-        private static int s_indentLevel;
+        private static TraceDebugBase _impl;
+        private static TraceDebugBase Impl
+        {
+            get
+            {
+                if (_impl == null)
+                {
+                    TraceDebugBase debugImplementation = null;
+                    Type typeFromTraceSource = null;
+                    try
+                    {
+                        // typeFromTraceSource = Type.GetType(
+                        //     "System.Diagnostics.TraceSource, System.Diagnostics.TraceInternal, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                        //     throwOnError: true);
+                        // typeFromTraceSource = null;
+                        // typeFromTraceSource = Type.GetType(
+                        //     "System.Diagnostics.TraceSource, System.Diagnostics.TraceDebug, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                        //     throwOnError: false);
+
+                        if (typeFromTraceSource != null)
+                        {
+                            debugImplementation = (TraceDebugBase)Activator.CreateInstance(typeFromTraceSource);
+                        }
+                    }
+                    catch (Exception) { } //replace with something more precise, would happen if CreateInstance fails
+
+                    if (debugImplementation == null)
+                    {
+                        debugImplementation = new DebugInternal();
+                    }
+
+                    System.Threading.Interlocked.CompareExchange(ref _impl, debugImplementation, null);
+                }
+                return _impl;
+            }
+        }
+
+        public static bool AutoFlush { get { return Impl.AutoFlush; } set { Impl.AutoFlush = value; } }
+
         public static int IndentLevel
         {
             get
             {
-                return s_indentLevel;
+                return Impl.IndentLevel;
             }
             set
             {
-                s_indentLevel = value < 0 ? 0 : value;
+                Impl.IndentLevel = value;
             }
         }
 
-        private static int s_indentSize = 4;
         public static int IndentSize
         {
             get
             {
-                return s_indentSize;
+                return Impl.IndentSize;
             }
             set
             {
-                s_indentSize = value < 0 ? 0 : value;
+                Impl.IndentSize = value;
             }
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        public static void Close() { }
+        public static void Close() { Impl.Close(); }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        public static void Flush() { }
+        public static void Flush() { Impl.Flush(); }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        public static void Indent()
-        {
-            IndentLevel++;
-        }
+        public static void Indent() { Impl.Indent(); }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        public static void Unindent()
-        {
-            IndentLevel--;
-        }
+        public static void Unindent() { Impl.Unindent(); }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Print(string message)
         {
-            Write(message);
+            Impl.Write(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Print(string format, params object[] args)
         {
-            Write(string.Format(null, format, args));
+            Impl.Write(string.Format(null, format, args));
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition)
         {
-            Assert(condition, string.Empty, string.Empty);
+            Impl.Assert(condition);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, string message)
         {
-            Assert(condition, message, string.Empty);
+            Impl.Assert(condition, message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, string message, string detailMessage)
         {
-            if (!condition)
-            {
-                string stackTrace;
-                try
-                {
-                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
-                }
-                catch
-                {
-                    stackTrace = "";
-                }
-                WriteLine(FormatAssert(stackTrace, message, detailMessage));
-                s_ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
-            }
+            Impl.Assert(condition, message, detailMessage);
         }
 
         internal static void ContractFailure(bool condition, string message, string detailMessage, string failureKindMessage)
@@ -119,7 +157,7 @@ namespace System.Diagnostics
                 {
                     stackTrace = "";
                 }
-                WriteLine(FormatAssert(stackTrace, message, detailMessage));
+                Impl.WriteLine(FormatAssert(stackTrace, message, detailMessage));
                 s_ShowDialog(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
             }
         }
@@ -127,16 +165,16 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Fail(string message)
         {
-            Assert(false, message, string.Empty);
+            Impl.Fail(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Fail(string message, string detailMessage)
         {
-            Assert(false, message, detailMessage);
+            Impl.Fail(message, detailMessage);
         }
 
-        private static string FormatAssert(string stackTrace, string message, string detailMessage)
+        internal static string FormatAssert(string stackTrace, string message, string detailMessage)
         {
             string newLine = GetIndentString() + Environment.NewLine;
             return SR.DebugAssertBanner + newLine
@@ -150,92 +188,61 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Assert(bool condition, string message, string detailMessageFormat, params object[] args)
         {
-            Assert(condition, message, string.Format(detailMessageFormat, args));
+            Impl.Assert(condition, message, string.Format(detailMessageFormat, args));
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string message)
         {
-            Write(message + Environment.NewLine);
+            Impl.WriteLine(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Write(string message)
         {
-            lock (s_lock)
-            {
-                if (message == null)
-                {
-                    s_WriteCore(string.Empty);
-                    return;
-                }
-                if (s_needIndent)
-                {
-                    message = GetIndentString() + message;
-                    s_needIndent = false;
-                }
-                s_WriteCore(message);
-                if (message.EndsWith(Environment.NewLine))
-                {
-                    s_needIndent = true;
-                }
-            }
+            Impl.Write(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(object value)
         {
-            WriteLine(value?.ToString());
+            Impl.WriteLine(value);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(object value, string category)
         {
-            WriteLine(value?.ToString(), category);
+            Impl.WriteLine(value, category);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string format, params object[] args)
         {
-            WriteLine(string.Format(null, format, args));
+            Impl.Write(string.Format(null, format, args));
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string message, string category)
         {
-            if (category == null)
-            {
-                WriteLine(message);
-            }
-            else
-            {
-                WriteLine(category + ":" + message);
-            }
+            Impl.WriteLine(message, category);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Write(object value)
         {
-            Write(value?.ToString());
+            Impl.Write(value);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Write(string message, string category)
         {
-            if (category == null)
-            {
-                Write(message);
-            }
-            else
-            {
-                Write(category + ":" + message);
-            }
+            Impl.Write(message, category);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Write(object value, string category)
         {
-            Write(value?.ToString(), category);
+            Impl.Write(value, category);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
@@ -243,7 +250,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                Write(message);
+                Impl.Write(message);
             }
         }
 
@@ -252,7 +259,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                Write(value);
+                Impl.Write(value);
             }
         }
 
@@ -261,7 +268,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                Write(message, category);
+                Impl.Write(message, category);
             }
         }
 
@@ -270,7 +277,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                Write(value, category);
+                Impl.Write(value, category);
             }
         }
 
@@ -279,7 +286,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                WriteLine(value);
+                Impl.WriteLine(value);
             }
         }
 
@@ -288,7 +295,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                WriteLine(value, category);
+                Impl.WriteLine(value, category);
             }
         }
 
@@ -297,7 +304,7 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                WriteLine(message);
+                Impl.WriteLine(message);
             }
         }
 
@@ -306,17 +313,15 @@ namespace System.Diagnostics
         {
             if (condition)
             {
-                WriteLine(message, category);
+                Impl.WriteLine(message, category);
             }
         }
 
-        private static bool s_needIndent;
-
         private static string s_indentString;
 
-        private static string GetIndentString()
+        internal static string GetIndentString()
         {
-            int indentCount = IndentSize * IndentLevel;
+            int indentCount = Impl.IndentSize * Impl.IndentLevel;
             if (s_indentString?.Length == indentCount)
             {
                 return s_indentString;
@@ -346,5 +351,161 @@ namespace System.Diagnostics
         internal static Action<string, string, string, string> s_ShowDialog = ShowDialog;
 
         internal static Action<string> s_WriteCore = WriteCore;
+    }
+
+    internal class DebugInternal : TraceDebugBase
+    {
+        private static readonly object s_lock = new object();
+        private static bool s_needIndent;
+
+        public override void Assert(bool condition)
+        {
+            Assert(condition, string.Empty, string.Empty);
+        }
+
+        public override void Assert(bool condition, string message)
+        {
+            Assert(condition, message, string.Empty);
+        }
+
+        public override void Assert(bool condition, string message, string detailMessage)
+        {
+            if (!condition)
+            {
+                string stackTrace;
+                try
+                {
+                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
+                }
+                catch
+                {
+                    stackTrace = "";
+                }
+                WriteLine(Debug.FormatAssert(stackTrace, message, detailMessage));
+                Debug.s_ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+            }
+        }
+
+        public override bool AutoFlush { get { return true; } set { } }
+
+        public override void Close() { }
+
+        public override void Fail(string message)
+        {
+            Assert(false, message, string.Empty);
+        }
+
+        public override void Fail(string message, string detailMessage)
+        {
+            Assert(false, message, detailMessage);
+        }
+
+        public override void Flush() { }
+
+        public override void Indent()
+        {
+            IndentLevel++;
+        }
+
+        public override void Unindent()
+        {
+            IndentLevel--;
+        }
+
+        [ThreadStatic]
+        private static int s_indentLevel;
+        public override int IndentLevel {
+            get
+            {
+                return s_indentLevel;
+            }
+            set
+            {
+                s_indentLevel = value < 0 ? 0 : value;
+            }
+        }
+
+        private static int s_indentSize = 4;
+        public override int IndentSize {
+            get
+            {
+                return s_indentSize;
+            }
+            set
+            {
+                s_indentSize = value < 0 ? 0 : value;
+            }
+        }
+
+        public override void Write(string message)
+        {
+            lock (s_lock)
+            {
+                if (message == null)
+                {
+                    Debug.s_WriteCore(string.Empty);
+                    return;
+                }
+                if (s_needIndent)
+                {
+                    message = Debug.GetIndentString() + message;
+                    s_needIndent = false;
+                }
+                Debug.s_WriteCore(message);
+                if (message.EndsWith(Environment.NewLine))
+                {
+                    s_needIndent = true;
+                }
+            }
+        }
+
+        public override void Write(object value)
+        {
+            Write(value?.ToString());
+        }
+
+        public override void Write(string message, string category)
+        {
+            if (category == null)
+            {
+                Write(message);
+            }
+            else
+            {
+                Write(category + ":" + message);
+            }
+        }
+
+        public override void Write(object value, string category)
+        {
+            Write(value?.ToString(), category);
+        }
+
+        public override void WriteLine(string message)
+        {
+            Write(message + Environment.NewLine);
+        }
+
+        public override void WriteLine(object value)
+        {
+            WriteLine(value?.ToString());
+        }
+
+        public override void WriteLine(object value, string category)
+        {
+            WriteLine(value?.ToString(), category);
+        }
+
+        public override void WriteLine(string message, string category)
+        {
+            if (category == null)
+            {
+                WriteLine(message);
+            }
+            else
+            {
+                WriteLine(category + ":" + message);
+            }
+        }
     }
 }


### PR DESCRIPTION
I completed @noahfalk prototype (introduced [here](https://github.com/dotnet/corefx/issues/3708#issuecomment-412248598)).
I do however get a StackOverflowException when I uncomment the reflection code in Debug.cs to get type from System.Debug.TraceSource

corefx changes here: https://github.com/maryamariyan/corefx/pull/27/files

Here's approach2: https://github.com/maryamariyan/coreclr/pull/8 and https://github.com/maryamariyan/corefx/pull/28
Approach 2 won't seem to be the best option since there are going to be multiple (10+) delegates to change using reflection.

I'm working on a third approach to still use an abstract class but the default implementation gets replaced by TraceInternal implementation within corefx rather than in coreclr.