### PR TITLE
Completed the design of DebugInternal, DebugProvider classes and the ReplaceInternal API

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -136,6 +136,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerStepperBoundaryAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerTypeProxyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerVisualizerAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugInternal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackFrame.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackTraceHiddenAttribute.cs" />

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugInternal.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugInternal.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Do not remove this, it is needed to retain calls to these conditional methods in release builds
+#define DEBUG
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Provides a default implementation for an internal portion of Debug class
+    /// that can be overriden to help link Debug with Trace Listeners
+    /// </summary>
+    public class DebugInternal
+    {
+        public virtual void Write(string message)
+        {
+            lock (s_lock)
+            {
+                if (message == null)
+                {
+                    Debug.Provider.Write(string.Empty);
+                    return;
+                }
+                if (_needIndent)
+                {
+                    message = GetIndentString() + message;
+                    _needIndent = false;
+                }
+                Debug.Provider.Write(message);
+                if (message.EndsWith(Environment.NewLine))
+                {
+                    _needIndent = true;
+                }
+            }
+        }
+        
+        public virtual void WriteLine(string message)
+        {
+            Write(message + Environment.NewLine);
+        }
+
+        public virtual void OnIndentLevelChanged(int indentLevel) { }
+
+        public virtual void OnIndentSizeChanged(int indentSize) { }
+
+        private static readonly object s_lock = new object();
+
+        private bool _needIndent = true;
+
+        private string _indentString;
+
+        private string GetIndentString()
+        {
+            int indentCount = Debug.IndentSize * Debug.IndentLevel;
+            if (_indentString?.Length == indentCount)
+            {
+                return _indentString;
+            }
+            return _indentString = new string(' ', indentCount);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -38,7 +38,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static void WriteCore(string message)
+        public virtual void Write(string message)
         {
             WriteToDebugger(message);
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -8,43 +8,10 @@
 namespace System.Diagnostics
 {
     /// <summary>
-    /// Provides default implementation for Write and ShowDialog methods in Debug class.
+    /// Enables Debug class with option to customize ShowDialog and Write
     /// </summary>
     public partial class DebugProvider
     {
-        public virtual void Write(string message)
-        {
-            lock (s_lock)
-            {
-                if (message == null)
-                {
-                    s_WriteCore(string.Empty);
-                    return;
-                }
-                if (_needIndent)
-                {
-                    message = GetIndentString() + message;
-                    _needIndent = false;
-                }
-                s_WriteCore(message);
-                if (message.EndsWith(Environment.NewLine))
-                {
-                    _needIndent = true;
-                }
-            }
-        }
-        
-        public virtual void WriteLine(string message)
-        {
-            Write(message + Environment.NewLine);
-        }
-
-        public virtual void OnIndentLevelChanged(int indentLevel) { }
-
-        public virtual void OnIndentSizeChanged(int indentSize) { }
-
-        private static readonly object s_lock = new object();
-
         private sealed class DebugAssertException : Exception
         {
             internal DebugAssertException(string stackTrace) :
@@ -62,22 +29,5 @@ namespace System.Diagnostics
             {
             }
         }
-
-        private bool _needIndent = true;
-
-        private string _indentString;
-
-        private string GetIndentString()
-        {
-            int indentCount = Debug.IndentSize * Debug.IndentLevel;
-            if (_indentString?.Length == indentCount)
-            {
-                return _indentString;
-            }
-            return _indentString = new string(' ', indentCount);
-        }
-
-        // internal and not readonly so that the tests can swap this out.
-        internal static Action<string> s_WriteCore = WriteCore;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -33,10 +33,10 @@ namespace System.Diagnostics
                 Environment.FailFast(ex.Message, ex, errorSource);
             }
         }
-
+    
         private static readonly object s_ForLock = new object();
 
-        private static void WriteCore(string message)
+        public virtual void Write(string message)
         {
             // really huge messages mess up both VS and dbmon, so we chop it up into 
             // reasonable chunks if it's too big. This is the number of characters 


### PR DESCRIPTION
This PR shows the new APIs used in order to:
- Wire up Debug with Trace Listeners
- Provide users with option to: (1) customize UI Dialog to show during `Debug/Trace.Fail`, and/or (2) control output sent to debugger. (The old s_WriteCore and s_ShowDialog delegates in Debug)

Related corefx changes for this coreclr PR:
https://github.com/maryamariyan/corefx/pull/31

API Proposal:

```
namespace System.Diagnostics
{
    /// <summary>
    /// Enables Debug class with option to customize ShowDialog and Write
    /// </summary>
    public partial class DebugProvider
    {
        public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource) { }
        public virtual void Write(string message) { }
    }

    /// <summary>
    /// Provides the default implementation for an internal portion of Debug class
    /// that can be overriden to help link Debug with Trace Listeners
    /// Intended use: Only within System.Diagnostics.TraceSource (would not need to go public)
    /// </summary>
    public partial class DebugInternal
    {
        public virtual void WriteLine(string message) { }
        public virtual void Write(string message) { }
        public virtual void OnIndentLevelChanged(int indentLevel) { }
        public virtual void OnIndentSizeChanged(int indentSize) { }
    }

    public static partial class Debug
    {
        // Enables Debug to get wired with Trace Listeners
        public static void ReplaceInternal(DebugInternal internals) { }
        // Enables (WPF) user with option to override ShowDialog and Write logic
        public static DebugProvider Provider { get { throw null; } set { } }
        ...
    }
}
```